### PR TITLE
fix: missing of second round resolve

### DIFF
--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -21,6 +21,14 @@ export const getPlugin = (): BunPlugin => ({
 			return { path, namespace };
 		});
 
+		build.onResolve({ filter: /^glob:/, namespace }, async (args) => {
+			const importData = imports.get(args.path);
+			if (!importData) {
+				return;
+			}
+			return { path: args.path, namespace };
+		});
+
 		build.onLoad({ filter: /^glob:/, namespace }, async (args) => {
 			const importData = imports.get(args.path);
 			if (!importData) {


### PR DESCRIPTION
Not sure starting in which version of bun, when `onResolve` returns different path or namespace, it will go though another round of resolution, which causing something like

```
error: Cannot find package 'glob-import-plugin:glob:c366a2ff1c1568ef.ts' from ...
```